### PR TITLE
Allow non-ASCII content from GitHub API

### DIFF
--- a/src/components/Frames/FramesView.js
+++ b/src/components/Frames/FramesView.js
@@ -8,7 +8,7 @@ const FramesView = ({
     {types.map((type, index) => (
         type === 'htmlpage' ?
             <FrameHTML key={index} index={index} /> :
-                <FrameCode key={index} index={index} />
+            <FrameCode key={index} index={index} />
     ))}
 </div>);
 

--- a/src/lib/get-github-file.js
+++ b/src/lib/get-github-file.js
@@ -21,7 +21,11 @@ export default async function getGithubFile(reqInfo) {
     let resp;
 
     try {
-        resp = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${ref}`);
+        resp = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${ref}`, {
+            headers: {
+                'Accept': 'application/vnd.github.VERSION.raw'
+            }
+        });
     } catch (e) {
         // fallback in case if API limmit is exceeded
         return makeDirectRequest(reqInfo);
@@ -31,11 +35,5 @@ export default async function getGithubFile(reqInfo) {
         return makeDirectRequest(reqInfo);
     }
 
-    const data = await resp.json();
-
-    if (!data.content) {
-        throw Error('Github API is returned wrong data');
-    }
-
-    return atob(data.content.replace(/\s/g, ''));
+    return await resp.text();
 }

--- a/src/lib/get-github-file.js
+++ b/src/lib/get-github-file.js
@@ -23,7 +23,7 @@ export default async function getGithubFile(reqInfo) {
     try {
         resp = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${ref}`, {
             headers: {
-                'Accept': 'application/vnd.github.VERSION.raw'
+                Accept: 'application/vnd.github.VERSION.raw'
             }
         });
     } catch (e) {


### PR DESCRIPTION
Adding the [`.raw`](https://developer.github.com/v3/repos/contents/#custom-media-types) media type accept header to GitHub API requests to skip base64 conversion which is limited to ASCII only.
This allows loading files with localized content the similar to `makeDirectRequest` while potentially reducing the payload size and skipping on decoding the content as well, so.. faster.